### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/core"]
 	path = src/core
-	url = git@github.com:Bobholamovic/DuduLearnsToCode-Core.git
+	url = https://github.com/Bobholamovic/DuduLearnsToCode-Core.git


### PR DESCRIPTION
Hello,  I found that I can not clone the submodule "src/core"  according to the old url, maybe it should be the new one.